### PR TITLE
[修复]现在默认用绝对路径输出log，修复了用相对路径输出有可能输出到/login.log而不是/root/login.log的问题

### DIFF
--- a/srun.sh
+++ b/srun.sh
@@ -69,14 +69,14 @@ if [ -z "$test_result" ]; then
     echo "User is online"
 else
     echo "User is offline, trying to reconnect..."
-    echo "$(date '+%Y-%m-%d %X') User is offline, trying to login..." >> ~/login.log
+    echo "$(date '+%Y-%m-%d %X') User is offline, trying to login..." >> /root/login.log
     # $1 用户名 $2 密码
     signin $1 $2
     if test $? -eq 1; then
         echo "User is connected"
-        echo "$(date '+%Y-%m-%d %X') User is logined successfully" >> ~/login.log
+        echo "$(date '+%Y-%m-%d %X') User is logined successfully" >> /root/login.log
     else
         echo "User connect failed"
-        echo "$(date '+%Y-%m-%d %X') User failed to login" >> ~/login.log
+        echo "$(date '+%Y-%m-%d %X') User failed to login" >> /root/login.log
     fi
 fi


### PR DESCRIPTION
~~其实直接执行和crontab都不会遇到这个bug~~

之前忘了提交…
建议给我加个collaborator（bushi